### PR TITLE
Fix 'double ack'.

### DIFF
--- a/app/models/listeners/enrollment_event_batch_handler.rb
+++ b/app/models/listeners/enrollment_event_batch_handler.rb
@@ -30,7 +30,6 @@ module Listeners
                                            :event_time => event_time.to_i.to_s
                                        })
       end
-      channel.ack(delivery_info.delivery_tag, false)
     end
     def create_batch_transaction(delivery_info, parsed_event, body, m_headers, event_time)
       EnrollmentEvents::Batch.create_batch_transaction_and_yield(parsed_event, body, m_headers, event_time) do |transaction|


### PR DESCRIPTION
There is an issue where the same message is acknowledged twice during batching, leading to a listener crash.