### PR TITLE
Fix employer timeout and merge trunk GHA files.

### DIFF
--- a/.github/workflows/docsite.yml
+++ b/.github/workflows/docsite.yml
@@ -3,16 +3,18 @@ on: push
 
 jobs:
   docs:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
-      - name: Set up Ruby 2.1.10
+      - name: Get Packages for Ruby Prerequisites
         run: |
-          sudo add-apt-repository -y ppa:brightbox/ruby-ng
           sudo apt-get -y update
-          sudo apt-get -y install ruby2.1 ruby2.1-dev ruby-switch
-          sudo apt-get -y install ruby-switch
-          sudo ruby-switch --list
-          sudo ruby-switch --set ruby2.1
+          sudo apt-get -y install git curl libssl1.0-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+      - name: Install Ruby
+        run: |
+          curl -O https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2
+          tar xjf ruby-2.1.10.tar.bz2
+          cd ruby-2.1.10 && ./configure && make -j 2
+          sudo make install
       - name: Setup Node.js for use with actions
         uses: actions/setup-node@v2.1.2
         with:

--- a/.github/workflows/push_checks.yml
+++ b/.github/workflows/push_checks.yml
@@ -3,16 +3,18 @@ on: push
 
 jobs:
   rspec:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
-      - name: Set up Ruby 2.1.10
+      - name: Get Packages for Ruby Prerequisites
         run: |
-          sudo add-apt-repository -y ppa:brightbox/ruby-ng
           sudo apt-get -y update
-          sudo apt-get -y install ruby2.1 ruby2.1-dev ruby-switch
-          sudo apt-get -y install ruby-switch
-          sudo ruby-switch --list
-          sudo ruby-switch --set ruby2.1
+          sudo apt-get -y install git curl libssl1.0-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev
+      - name: Install Ruby
+        run: |
+          curl -O https://cache.ruby-lang.org/pub/ruby/2.1/ruby-2.1.10.tar.bz2
+          tar xjf ruby-2.1.10.tar.bz2
+          cd ruby-2.1.10 && ./configure && make -j 2
+          sudo make install
       - name: Launch MongoDB
         uses: wbari/start-mongoDB@v0.2
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'nokogiri-happymapper', "~> 0.5.9", :require => 'happymapper'
 gem 'prawn', '~> 2.2'
 gem 'prawn-templates', '~> 0.1.2'
 gem 'forkr', '1.0.2'
-gem 'edi_codec', git: "https://github.com/ideacrew/edi_codec.git"
+gem 'edi_codec', git: "https://github.com/ideacrew/edi_codec.git", branch: "trunk"
 gem 'ibsciss-middleware', git: "https://github.com/ideacrew/ruby-middleware.git", branch: "trunk", :require => "middleware"
 gem 'rgl', '0.5.2'
 gem 'aws-sdk', "~> 2.2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/ideacrew/edi_codec.git
-  revision: bbd593e0312c7e9992bc0491d5bf7ce56ef61f7a
+  revision: 6d1e67f170c329fcf953a93064d72f1b7ab147e1
+  branch: trunk
   specs:
     edi_codec (0.1.2)
       activesupport (>= 3.2)

--- a/app/models/listeners/employer_event_reducer_listener.rb
+++ b/app/models/listeners/employer_event_reducer_listener.rb
@@ -36,7 +36,7 @@ module Listeners
 
     def request_resource(employer_id, plan_year_id = nil)
       begin
-        di, rprops, resp_body = request({:headers => {:employer_id => employer_id, :plan_year_id => plan_year_id}, :routing_key => "resource.employer"},"", 30)
+        di, rprops, resp_body = request({:headers => {:employer_id => employer_id, :plan_year_id => plan_year_id}, :routing_key => "resource.employer"},"", 90)
         r_headers = (rprops.headers || {}).to_hash.stringify_keys
         r_code = r_headers['return_status'].to_s
         if r_code == "200"


### PR DESCRIPTION
Correct both the employer timeout issue and the subscriber ordering issue in X12 XMLs.

The edi_codec gem update was reviewed under: https://github.com/ideacrew/edi_codec/pull/8

Also be aware that as this is a hotfix, and DC currently has older code deployed, this branch is based off of tag dc-4.10.18.

I thus recommend we cut the next release as dc-4.11.0, denoting the fact that it is 'disconnected' from trunk by usage of the old version numbering.