### PR TITLE
Refactor enrollment batch processing to be more scalable.

### DIFF
--- a/script/amqp/employer_workers.rb
+++ b/script/amqp/employer_workers.rb
@@ -9,5 +9,5 @@ MultiForkr.new({
   Listeners::ReportEligibilityUpdatedReducerListener => 1,
   Listeners::ReportEligibilityUpdatedDigestDropListener => 1,
   Listeners::EnrollmentEventBatchHandler => 1,
-  Listeners::EnrollmentEventBatchProcessor => 6
+  Listeners::EnrollmentEventBatchProcessor => 1
 }).run

--- a/script/amqp/enrollment_event_batch_processor.rb
+++ b/script/amqp/enrollment_event_batch_processor.rb
@@ -1,0 +1,2 @@
+Rails.application.eager_load!
+Listeners::EnrollmentEventBatchProcessor.run


### PR DESCRIPTION
Break the enrollment batch handler into its own runtime so that DevOps can scale it as desired.

The new command will be `bundle exec rails r -e production script/amqp/enrollment_event_batch_processor.rb`