### PR TITLE
Tighten update criteria for inbound terms.

### DIFF
--- a/app/models/parsers/edi/person_loop_validator.rb
+++ b/app/models/parsers/edi/person_loop_validator.rb
@@ -11,7 +11,8 @@ module Parsers
         when "030"
           valid = (person_loop.change_reason == "XN")
         when "024"
-          valid = true
+          allowed_values = ["59", "33"]
+          valid = allowed_values.include?(person_loop.change_reason)
         when "025"
           allowed_values = ["EC", "41"]
           valid = allowed_values.include?(person_loop.change_reason)

--- a/spec/models/parsers/edi/etf/person_loop_validator_spec.rb
+++ b/spec/models/parsers/edi/etf/person_loop_validator_spec.rb
@@ -46,7 +46,7 @@ describe Parsers::Edi::PersonLoopValidator, "given a termination on an existing 
       :policy_loops => [policy_loop],
       :reinstate? => false,
       :change_code => "024",
-      :change_reason => nil,
+      :change_reason => "33",
       :subscriber? => true
      )
   end


### PR DESCRIPTION
Prevent inbound terminations from affecting policy status when the termination reason is not 33 or 59.

ME-183750844