### PR TITLE
Reduce broker update transaction noise.

### DIFF
--- a/app/models/listeners/enrollment_broker_updated_listener.rb
+++ b/app/models/listeners/enrollment_broker_updated_listener.rb
@@ -47,9 +47,11 @@ module Listeners
     end
 
     def update_broker_on_policy(broker_id, policy)
-      policy.broker_id = broker_id
-      policy.save!
-      publish_to_edi(policy)
+      if policy.broker_id != broker_id
+        policy.broker_id = broker_id
+        policy.save!
+        publish_to_edi(policy)
+      end
     end
 
     def publish_to_edi(policy)


### PR DESCRIPTION
Previously transactions would be sent even if the 'new' broker matched the old broker.  Now such notification are consumed without generating EDI or database updates.