### PR TITLE
fixed dev docker build by upgrading the base image

### DIFF
--- a/.docker/development/Dockerfile
+++ b/.docker/development/Dockerfile
@@ -1,13 +1,13 @@
-FROM --platform=linux/amd64 ruby:2.1.7 AS base
+FROM --platform=linux/amd64 ghcr.io/ideacrew/gluedb:base AS base
 
 LABEL author="IdeaCrew"
 
 # Install required packages/libraries
 RUN apt-get update && \
     apt-get -yq dist-upgrade && \
-    apt-get install -y git gcc openssl libyaml-dev libyaml-cpp-dev libyaml-cpp0.5 libffi-dev libffi6 libreadline-dev \
+    apt-get install -y git gcc openssl libyaml-dev libyaml-cpp-dev libyaml-cpp0.5v5 libffi-dev libffi6 libreadline-dev \
                        zlibc libgdbm-dev libncurses-dev autoconf fontconfig unzip zip sshpass bzip2 libxrender1 libxext6 \
-                       build-essential && \
+                       build-essential libxml2 libxml2-dev libxslt1-dev && \
     apt-get autoremove -y
 
 ENV LANG=C.UTF-8
@@ -26,3 +26,4 @@ ENV BUNDLE_GITHUB__COM=x-access-token:"$GEM_OAUTH_TOKEN"
 RUN bundle install --jobs 20 --retry 5
 
 COPY .docker/development/mongoid.yml config/mongoid.yml
+


### PR DESCRIPTION
the old ruby image used Debian jessie, and the signatures are invalid because they are old. This fixes the build by reusing the image that we use for glue production but adding the required packages to do development 