### PR TITLE
add batch processor listener to glue-update

### DIFF
--- a/.docker/config/glue_update.sh
+++ b/.docker/config/glue_update.sh
@@ -188,8 +188,8 @@ if [ "$update_status" -eq 1 ]; then
   sleep 120
   kubectl scale --replicas=2 deployment/edidb-enrollment-validator deployment/edidb-broker-updated-listener \
                              deployment/edidb-policy-id-list-listener deployment/edidb-enrollment-event-listener \
-                             deployment/edidb-enrollment-event-handler
-  kubectl scale --replicas=1 deployment/edidb-enrollment-event-batch-processor
+                             deployment/edidb-enrollment-event-handler \
+                             deployment/edidb-enrollment-event-batch-processor
   sleep 120
   kubectl patch cronjobs edidb-glue-batch -p "{\"spec\" : {\"suspend\" : false }}"
   kubectl rollout restart deployment edidb-$ENV_NAME

--- a/.docker/config/glue_update.sh
+++ b/.docker/config/glue_update.sh
@@ -124,7 +124,7 @@ fi
 echo "bringing down listeners: "$(date)
 kubectl scale --replicas=0  deployment/edidb-enrollment-validator deployment/edidb-broker-updated-listener \
                             deployment/edidb-policy-id-list-listener deployment/edidb-enrollment-event-listener \
-                            deployment/edidb-enrollment-event-handler
+                            deployment/edidb-enrollment-event-handler deployment/edidb-enrollment-event-batch-processor
 sleep 60
 kubectl scale --replicas=0 deployment/edidb-enroll-query-result-handler
 sleep 120
@@ -189,6 +189,7 @@ if [ "$update_status" -eq 1 ]; then
   kubectl scale --replicas=2 deployment/edidb-enrollment-validator deployment/edidb-broker-updated-listener \
                              deployment/edidb-policy-id-list-listener deployment/edidb-enrollment-event-listener \
                              deployment/edidb-enrollment-event-handler
+  kubectl scale --replicas=1 deployment/edidb-enrollment-event-batch-processor
   sleep 120
   kubectl patch cronjobs edidb-glue-batch -p "{\"spec\" : {\"suspend\" : false }}"
   kubectl rollout restart deployment edidb-$ENV_NAME


### PR DESCRIPTION
Adding enrollment-event-batch-processor listener to glue-update script so that this listener don't process anything in the rabbit.