### PR TITLE
Merge pull request #55 from ideacrew/180365353-fix-missing-terms

### DIFF
--- a/app/models/external_events/enrollment_event_notification_filters/remove_same_actions_and_select_silent.rb
+++ b/app/models/external_events/enrollment_event_notification_filters/remove_same_actions_and_select_silent.rb
@@ -4,16 +4,31 @@ module ExternalEvents
       def filter(full_event_list)
         full_event_list.inject([]) do |acc, event|
           duplicate_found = acc.detect do |item|
-            [event.hbx_enrollment_id, event.enrollment_action] == [item.hbx_enrollment_id, item.enrollment_action]
+            [event.hbx_enrollment_id, event_comparison_action(event.enrollment_action)] == [item.hbx_enrollment_id, event_comparison_action(item.enrollment_action)]
           end
-          if duplicate_found
-            # Favor the event marked as silent
+          # Favor the event marked as silent in the case of terminations
+          if duplicate_found && event.is_termination?
             if (!duplicate_found.is_publishable?)
               event.drop_payload_duplicate!
               acc
             elsif (!event.is_publishable?)
               filtered_accs = acc.reject do |item|
-                [event.hbx_enrollment_id, event.enrollment_action] == [item.hbx_enrollment_id, item.enrollment_action]
+                [event.hbx_enrollment_id, event_comparison_action(event.enrollment_action)] == [item.hbx_enrollment_id, event_comparison_action(item.enrollment_action)]
+              end
+              duplicate_found.drop_payload_duplicate!
+              filtered_accs + [event]
+            else
+              event.drop_payload_duplicate!
+              acc
+            end
+          # In the case of initials, favor the event marked as auto_renewal if it exists
+          elsif duplicate_found && event.is_coverage_starter?
+            if (duplicate_found.is_passive_renewal?)
+              event.drop_payload_duplicate!
+              acc
+            elsif (event.is_passive_renewal?)
+              filtered_accs = acc.reject do |item|
+                [event.hbx_enrollment_id, event_comparison_action(event.enrollment_action)] == [item.hbx_enrollment_id, event_comparison_action(item.enrollment_action)]
               end
               duplicate_found.drop_payload_duplicate!
               filtered_accs + [event]
@@ -25,6 +40,12 @@ module ExternalEvents
             acc + [event]
           end
         end
+      end
+
+      def event_comparison_action(event_action)
+        events_counting_as_coverage_selected = ExternalEvents::EnrollmentEventNotification::COVERAGE_START_EVENTS
+        return "urn:openhbx:terms:v1:enrollment#initial" if events_counting_as_coverage_selected.include?(event_action)
+        event_action
       end
     end
   end

--- a/spec/models/external_events/enrollment_event_notification_filters/remove_same_actions_and_select_silent_spec.rb
+++ b/spec/models/external_events/enrollment_event_notification_filters/remove_same_actions_and_select_silent_spec.rb
@@ -10,7 +10,8 @@ describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActions
       ::ExternalEvents::EnrollmentEventNotification,
       :hbx_enrollment_id => "A",
       :enrollment_action => "terminate",
-      :is_publishable? => true
+      :is_publishable? => true,
+      :is_termination? => true
     )
   end
 
@@ -19,7 +20,8 @@ describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActions
       ::ExternalEvents::EnrollmentEventNotification,
       :hbx_enrollment_id => "A",
       :enrollment_action => "terminate",
-      :is_publishable? => false
+      :is_publishable? => false,
+      :is_termination? => true
     )
   end
 
@@ -54,7 +56,8 @@ describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActions
       ::ExternalEvents::EnrollmentEventNotification,
       :hbx_enrollment_id => "A",
       :enrollment_action => "terminate",
-      :is_publishable? => true
+      :is_publishable? => true,
+      :is_termination? => true
     )
   end
 
@@ -63,7 +66,8 @@ describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActions
       ::ExternalEvents::EnrollmentEventNotification,
       :hbx_enrollment_id => "A",
       :enrollment_action => "terminate",
-      :is_publishable? => false
+      :is_publishable? => false,
+      :is_termination? => true
     )
   end
 
@@ -83,6 +87,106 @@ describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActions
 
   it "drops the loud termination event as a duplicate" do
     expect(event_1).to receive(:drop_payload_duplicate!)
+    subject.filter(events)
+  end
+
+end
+
+describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActionsAndSelectSilent, "given, in order:
+- a coverage_selected for enrollment 'A'
+- an auto_renew for enrollment 'A'
+" do
+
+  let(:event_1) do
+    instance_double(
+      ::ExternalEvents::EnrollmentEventNotification,
+      :hbx_enrollment_id => "A",
+      :enrollment_action => "urn:openhbx:terms:v1:enrollment#initial",
+      :is_publishable? => true,
+      :is_termination? => false,
+      :is_coverage_starter? => true,
+      :is_passive_renewal? => false
+    )
+  end
+
+  let(:event_2) do
+    instance_double(
+      ::ExternalEvents::EnrollmentEventNotification,
+      :hbx_enrollment_id => "A",
+      :enrollment_action => "urn:openhbx:terms:v1:enrollment#auto_renew",
+      :is_publishable? => false,
+      :is_termination? => false,
+      :is_coverage_starter? => true,
+      :is_passive_renewal? => true
+    )
+  end
+
+  let(:events) { [event_1, event_2] }
+
+  before :each do
+    allow(event_1).to receive(:drop_payload_duplicate!)
+  end
+
+  it "filters the coverage_selected event" do
+    expect(subject.filter(events)).not_to include(event_1)
+  end
+
+  it "includes the auto_renewal event" do
+    expect(subject.filter(events)).to include(event_2)
+  end
+
+  it "drops the coverage_selected event as a duplicate" do
+    expect(event_1).to receive(:drop_payload_duplicate!)
+    subject.filter(events)
+  end
+
+end
+
+describe ::ExternalEvents::EnrollmentEventNotificationFilters::RemoveSameActionsAndSelectSilent, "given, in order:
+- an auto_renewal for enrollment 'A'
+- a coverage_selected for enrollment 'A'
+" do
+
+  let(:event_1) do
+    instance_double(
+      ::ExternalEvents::EnrollmentEventNotification,
+      :hbx_enrollment_id => "A",
+      :enrollment_action => "urn:openhbx:terms:v1:enrollment#auto_renew",
+      :is_publishable? => true,
+      :is_termination? => false,
+      :is_coverage_starter? => true,
+      :is_passive_renewal? => true
+    )
+  end
+
+  let(:event_2) do
+    instance_double(
+      ::ExternalEvents::EnrollmentEventNotification,
+      :hbx_enrollment_id => "A",
+      :enrollment_action => "urn:openhbx:terms:v1:enrollment#initial",
+      :is_publishable? => false,
+      :is_termination? => false,
+      :is_coverage_starter? => true,
+      :is_passive_renewal? => false
+    )
+  end
+
+  let(:events) { [event_1, event_2] }
+
+  before :each do
+    allow(event_2).to receive(:drop_payload_duplicate!)
+  end
+
+  it "filters the coverage_selected event" do
+    expect(subject.filter(events)).not_to include(event_2)
+  end
+
+  it "includes the auto_renewal event" do
+    expect(subject.filter(events)).to include(event_1)
+  end
+
+  it "drops the coverage_selected event as a duplicate" do
+    expect(event_2).to receive(:drop_payload_duplicate!)
     subject.filter(events)
   end
 


### PR DESCRIPTION
Ticket: [TT6-186692128](https://www.pivotaltracker.com/n/projects/2640057/stories/186692128)

Note: this PR simply cherry picks a single commit from the `me_carrier_boarding` branch that corrects a bug in the logic for interpreting events, which was never resolved on trunk.  

The problematic scenario occurs when:
 1. An autorenewal enrollment has been generated in coverage_selected state
 2. The autorenewal enrollment moves to unverified
 3. The autorenewal enrollment moves back to coverage_selected
 4. The autorenewal enrollment moves to coverage_canceled

Only the coverage_selected and coverage_canceled events are transmitted to Glue.  Since transmissions are sent in batches, these events may occur all within a single batch or be split across multiple batches.

The updates to `RemoveSameActionsAndSelectSilent` correct the logic when all events are sent in the same batch, while the updates to `EnrollmentEventNotification` correct the logic when the events are spread across multiple batches.

Original commit message:
`Correct missing terminations and incorrect interpretation of events.`